### PR TITLE
Revert "Output Next assets to `out` dir"

### DIFF
--- a/frontend/next.config.mjs
+++ b/frontend/next.config.mjs
@@ -17,8 +17,6 @@ const nextConfig = {
       },
     ],
   },
-  // output static assets to `out` dir
-  output: 'export',
 };
 
 export default nextConfig;


### PR DESCRIPTION
This reverts commit 83d14e750f51616aa48dfd103fe3d0815d4a3bf9.

This NextJS site uses the `cookies` module, which makes it ineligible to be deployed as static assets.